### PR TITLE
fix: spelling improvement

### DIFF
--- a/src/components/Bucket.vue
+++ b/src/components/Bucket.vue
@@ -12,7 +12,7 @@
       <strong>how sure you are</strong> about how long they will take.
     </p>
     <p class="body-text">
-      All data is preserved in your browser's local storage, but not transmitted or stored anywhere else. Made by Mark Noonan (<a href="https://twitter.com/marktnoonan">@marktnoonan</a>) as an experiment to help me manage my time better. Feel free to try it out. The code for this project is available on <a href="https://github.com/marktnoonan/obligabucket">Github</a>.
+      All data is preserved in your browser's local storage, but not transmitted or stored anywhere else. Made by Mark Noonan (<a href="https://twitter.com/marktnoonan">@marktnoonan</a>) as an experiment to help me manage my time better. Feel free to try it out. The code for this project is available on <a href="https://github.com/marktnoonan/obligabucket">GitHub</a>.
     </p>
     <hr />
     <details open>


### PR DESCRIPTION
- Spelling improvement
  - Change `Github` to `GitHub`